### PR TITLE
fix: Add pywin32 as requirements

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -38,7 +38,9 @@ status = 2
 user = JunDamin
 
 ### Optional ###
-requirements = fastcore
+requirements = 
+    fastcore
+    pywin32
 # dev_requirements = 
 # console_scripts =
 


### PR DESCRIPTION
`hwpapi`는 win32를 쓰는데 그에 대한 requirements로 `pywin32`가 없어 새로운 가상환경에서 hwpapi만 설치 후 사용 시 에러가 납니다.

```
(venv) C:\Users\OWNER\Documents\_github\hwp-automation>python run.py
Traceback (most recent call last):
  File "C:\Users\OWNER\Documents\_github\hwp-automation\run.py", line 1, in <module>
    from hwpapi.core import App
  File "C:\Users\OWNER\Documents\_github\hwp-automation\venv\Lib\site-packages\hwpapi\core.py", line 17, in <module>
    from .dataclasses import CharShape, ParaShape
  File "C:\Users\OWNER\Documents\_github\hwp-automation\venv\Lib\site-packages\hwpapi\dataclasses.py", line 20, in <module>   
    from hwpapi.functions import (
    import win32com.client as win32
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'win32com'
```

해당 PR은 pywin32를 requirements에 넣어 해당 오류를 수정합니다.

Ps. 로컬에서 바로 설치할떄, 디렉토리 명이 `hwpapi`가 아닌 `HwpApi` 라서 로컬 설치 시 에러가 나는데 해당 부분은 의도한 것인가요?